### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,9 +105,9 @@ subprojects {
 
 	ext {
 		javadocLinks = [
-				'http://docs.oracle.com/javase/7/docs/api/',
-				'http://docs.oracle.com/javaee/6/api/',
-				'http://docs.spring.io/spring/docs/current/javadoc-api/',
+				'https://docs.oracle.com/javase/7/docs/api/',
+				'https://docs.oracle.com/javaee/6/api/',
+				'https://docs.spring.io/spring/docs/current/javadoc-api/',
 		] as String[]
 	}
 

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -39,12 +39,12 @@ def customizePom(pom, gradleProject) {
 			url = "https://github.com/pivotal-cf/spring-cloud-vault-connector"
 			organization {
 				name = "Spring IO"
-				url = "http://projects.spring.io/spring-cloud"
+				url = "https://projects.spring.io/spring-cloud"
 			}
 			licenses {
 				license {
 					name "The Apache Software License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+					url "https://www.apache.org/licenses/LICENSE-2.0.txt"
 					distribution "repo"
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javaee/6/api/ migrated to:  
  https://docs.oracle.com/javaee/6/api/ ([https](https://docs.oracle.com/javaee/6/api/) result 200).
* http://docs.oracle.com/javase/7/docs/api/ migrated to:  
  https://docs.oracle.com/javase/7/docs/api/ ([https](https://docs.oracle.com/javase/7/docs/api/) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://projects.spring.io/spring-cloud migrated to:  
  https://projects.spring.io/spring-cloud ([https](https://projects.spring.io/spring-cloud) result 301).