### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you'd rather like the latest snapshots of the upcoming major version, use our
 <repository>
   <id>spring-libs-snapshot</id>
   <name>Spring Snapshot Repository</name>
-  <url>http://repo.spring.io/libs-snapshot</url>
+  <url>https://repo.spring.io/libs-snapshot</url>
 </repository>
 ```
 

--- a/spring-cloud-vault-cloudfoundry-connector/src/test/java/io/pivotal/spring/cloud/vault/cloudfoundry/VaultServiceInfoCreatorUnitTests.java
+++ b/spring-cloud-vault-cloudfoundry-connector/src/test/java/io/pivotal/spring/cloud/vault/cloudfoundry/VaultServiceInfoCreatorUnitTests.java
@@ -60,7 +60,7 @@ public class VaultServiceInfoCreatorUnitTests extends AbstractCloudFoundryConnec
 		Map services = readServiceData("test-vault-service.json");
 		Map<String, Object> serviceData = getServiceData(services, "hashicorp-vault");
 
-		// address: http://192.168.11.11:8200/
+		// address: https://192.168.11.11:8200/
 		// auth.token: d6754590-7b1a-3f36-5260-5bc68e27d95c
 		// backends: secret, generic
 		// backends_shared: organization, space

--- a/spring-cloud-vault-cloudfoundry-connector/src/test/resources/io/pivotal/spring/cloud/vault/cloudfoundry/test-vault-service-single.json
+++ b/spring-cloud-vault-cloudfoundry-connector/src/test/resources/io/pivotal/spring/cloud/vault/cloudfoundry/test-vault-service-single.json
@@ -2,7 +2,7 @@
   "hashicorp-vault": [
 	{
 	  "credentials": {
-		"address": "http://192.168.11.11:8200/",
+		"address": "https://192.168.11.11:8200/",
 		"auth": {
 		  "accessor": "4418eac7-04e2-e5f2-aa26-78945a64fec6",
 		  "token": "d6754590-7b1a-3f36-5260-5bc68e27d95c"

--- a/spring-cloud-vault-cloudfoundry-connector/src/test/resources/io/pivotal/spring/cloud/vault/cloudfoundry/test-vault-service.json
+++ b/spring-cloud-vault-cloudfoundry-connector/src/test/resources/io/pivotal/spring/cloud/vault/cloudfoundry/test-vault-service.json
@@ -2,7 +2,7 @@
   "hashicorp-vault": [
 	{
 	  "credentials": {
-		"address": "http://192.168.11.11:8200/",
+		"address": "https://192.168.11.11:8200/",
 		"auth": {
 		  "accessor": "4418eac7-04e2-e5f2-aa26-78945a64fec6",
 		  "token": "d6754590-7b1a-3f36-5260-5bc68e27d95c"

--- a/spring-cloud-vault-connector-core/src/test/java/io/pivotal/spring/cloud/vault/service/common/VaultServiceInfoUnitTests.java
+++ b/spring-cloud-vault-connector-core/src/test/java/io/pivotal/spring/cloud/vault/service/common/VaultServiceInfoUnitTests.java
@@ -39,7 +39,7 @@ public class VaultServiceInfoUnitTests {
 		backends.add("cf/20fffe9d-d8d1-4825-9977-1426840a13dc/transit");
 
 		VaultServiceInfo info = new VaultServiceInfo("vault",
-				"http://192.168.11.11:8200/", "foo".toCharArray(),
+				"https://192.168.11.11:8200/", "foo".toCharArray(),
 				Collections.singletonMap("transit", backends), Collections.emptyMap());
 
 		assertThat(info.getToken()).isEqualTo("foo".toCharArray());

--- a/spring-cloud-vault-localconfig-connector/README.md
+++ b/spring-cloud-vault-localconfig-connector/README.md
@@ -21,7 +21,7 @@ http://localhost:8200?token=my-token&backend.generic=cf/secret&backend.transit=c
 ```
 
 The Spring Cloud localconfig connector documentation quick start, at:
-http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html#_local_configuration_connector
+https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html#_local_configuration_connector
 
 With the Vault localconfig connector, you can do the same for Vault, like so:
 

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/ServiceInfoPropertySourceAdapter.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/ServiceInfoPropertySourceAdapter.java
@@ -33,8 +33,8 @@ import org.springframework.core.env.PropertySource;
  * @author Will Tran
  * @author Mark Paluch
  * @see <a href=
- * "http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config">
- * http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config</a>
+ * "https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config">
+ * https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config</a>
  */
 abstract class ServiceInfoPropertySourceAdapter<T extends ServiceInfo> implements
 		ApplicationListener<ApplicationEnvironmentPreparedEvent>, Ordered {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://192.168.11.11:8200/ (ConnectTimeoutException) with 4 occurrences migrated to:  
  https://192.168.11.11:8200/ ([https](https://192.168.11.11:8200/) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html) result 200).
* http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html) result 200).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:10334/ with 1 occurrences
* http://localhost:10334/?token=foo&backend.transit=cf/transit&shared_backend.generic=cf/secret with 1 occurrences
* http://localhost:8200 with 3 occurrences
* http://localhost:8200?token=my-token with 1 occurrences
* http://localhost:8200?token=my-token&backend.generic=cf/secret&backend.transit=cf/transit&shared_backend=space=cf/space with 2 occurrences