### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@ Apache License
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-cloudfoundry-connector/src/main/java/io/pivotal/spring/cloud/vault/cloudfoundry/VaultServiceInfoCreator.java
+++ b/spring-cloud-vault-cloudfoundry-connector/src/main/java/io/pivotal/spring/cloud/vault/cloudfoundry/VaultServiceInfoCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-cloudfoundry-connector/src/test/java/io/pivotal/spring/cloud/vault/cloudfoundry/VaultServiceInfoCreatorUnitTests.java
+++ b/spring-cloud-vault-cloudfoundry-connector/src/test/java/io/pivotal/spring/cloud/vault/cloudfoundry/VaultServiceInfoCreatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-connector-core/src/main/java/io/pivotal/spring/cloud/vault/service/common/VaultServiceInfo.java
+++ b/spring-cloud-vault-connector-core/src/main/java/io/pivotal/spring/cloud/vault/service/common/VaultServiceInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-connector-core/src/test/java/io/pivotal/spring/cloud/vault/service/common/VaultServiceInfoUnitTests.java
+++ b/spring-cloud-vault-connector-core/src/test/java/io/pivotal/spring/cloud/vault/service/common/VaultServiceInfoUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-localconfig-connector/src/main/java/io/pivotal/spring/cloud/vault/localconfig/VaultServiceInfoCreator.java
+++ b/spring-cloud-vault-localconfig-connector/src/main/java/io/pivotal/spring/cloud/vault/localconfig/VaultServiceInfoCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-localconfig-connector/src/test/java/io/pivotal/spring/cloud/localconfig/VaultServiceInfoCreatorUnitTests.java
+++ b/spring-cloud-vault-localconfig-connector/src/test/java/io/pivotal/spring/cloud/localconfig/VaultServiceInfoCreatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/AppNameBootstrapConfiguration.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/AppNameBootstrapConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/ServiceInfoPropertySourceAdapter.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/ServiceInfoPropertySourceAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultCloudServiceConnectionFactory.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultCloudServiceConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultConnectorBootstrapConfiguration.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultConnectorBootstrapConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultConnectorConfigurer.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultConnectorConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultConnectorGenericBackendProperties.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultConnectorGenericBackendProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultConnectorsConfig.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultConnectorsConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultServiceConnectionFactory.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultServiceConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultServiceInfoPropertySourceAdapter.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/config/java/VaultServiceInfoPropertySourceAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/service/VaultServiceConnectorConfig.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/service/VaultServiceConnectorConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/service/VaultTemplateCreator.java
+++ b/spring-cloud-vault-spring-connector/src/main/java/io/pivotal/spring/cloud/vault/service/VaultTemplateCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/MockCloudConnector.java
+++ b/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/MockCloudConnector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/StubCloudConnectorTest.java
+++ b/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/StubCloudConnectorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/config/AbstractCloudConfigServiceTest.java
+++ b/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/config/AbstractCloudConfigServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/config/java/AbstractServiceJavaConfigTest.java
+++ b/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/config/java/AbstractServiceJavaConfigTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/config/java/ServiceInfoPropertySourceAdapterUnitTests.java
+++ b/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/config/java/ServiceInfoPropertySourceAdapterUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/config/java/VaultTemplateJavaConfigTests.java
+++ b/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/config/java/VaultTemplateJavaConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/service/VaultTemplateCreatorUnitTests.java
+++ b/spring-cloud-vault-spring-connector/src/test/java/io/pivotal/spring/cloud/vault/service/VaultTemplateCreatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/dist/license.txt
+++ b/src/dist/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 26 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).